### PR TITLE
Add null check on existing map bounds in fitToBounds

### DIFF
--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapWidget.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapWidget.java
@@ -715,7 +715,8 @@ public class GoogleMapWidget extends FlowPanel implements RequiresResize {
         LatLng sw = LatLng.newInstance(boundsSW.getLat(), boundsSW.getLon());
 
         LatLngBounds bounds = LatLngBounds.newInstance(sw, ne);
-        if (map.getBounds().equals(bounds)) {
+        final LatLngBounds mapBounds = map.getBounds();
+        if (mapBounds != null && mapBounds.equals(bounds)) {
             return;
         }
         map.fitBounds(bounds);


### PR DESCRIPTION
Before comparing existing map bounds to the desired bounds in
GoogleMapWidget.fitToBounds, ensure that exising map bounds aren't null.
This can happen if calling fitToBounds on a newly-added map.