### PR TITLE
Fix parameter name associated with API key

### DIFF
--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapConnector.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapConnector.java
@@ -93,7 +93,7 @@ public class GoogleMapConnector extends AbstractComponentContainerConnector
         if (getState().clientId != null) {
             params = "client=" + getState().clientId;
         } else if (getState().apiKey != null) {
-            params = "APIKEY=" + getState().apiKey;
+            params = "key=" + getState().apiKey;
         }
 
         if (getState().apiUrl != null) {


### PR DESCRIPTION
When loading the Google Maps API, provide the API key using parameter 'key'
rather than 'APIKEY'.
Resolves tjkaal/GoogleMapsVaadin7#40.